### PR TITLE
Update default themes to use Material colors

### DIFF
--- a/MaterialNavigationDrawerModule/src/main/res/values/themes.xml
+++ b/MaterialNavigationDrawerModule/src/main/res/values/themes.xml
@@ -3,7 +3,7 @@
 
     <style name="MaterialNavigationDrawerTheme" parent="Theme.AppCompat.NoActionBar" >
         <item name="drawerType">@integer/DRAWERTYPE_ACCOUNTS</item>
-        <item name="drawerColor">#111</item>
+        <item name="drawerColor">#ff303030</item>
         <item name="rippleBackport">false</item>
         <item name="uniqueToolbarColor">false</item>
         <item name="singleAccount">false</item>
@@ -17,7 +17,7 @@
 
     <style name="MaterialNavigationDrawerTheme.Light" parent="Theme.AppCompat.Light.NoActionBar" >
         <item name="drawerType">@integer/DRAWERTYPE_ACCOUNTS</item>
-        <item name="drawerColor">#fafafa</item>
+        <item name="drawerColor">#ffeeeeee</item>
         <item name="rippleBackport">false</item>
         <item name="uniqueToolbarColor">false</item>
         <item name="singleAccount">false</item>
@@ -33,7 +33,7 @@
         <item name="theme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
         <item name="popupTheme">@style/Base.V21.Theme.AppCompat.Light.Dialog</item>
         <item name="drawerType">@integer/DRAWERTYPE_ACCOUNTS</item>
-        <item name="drawerColor">#fafafa</item>
+        <item name="drawerColor">#ffeeeeee</item>
         <item name="rippleBackport">false</item>
         <item name="uniqueToolbarColor">false</item>
         <item name="singleAccount">false</item>


### PR DESCRIPTION
Pulled colors from appcompat v22:
ffeeeeee @color/background_material_light
ff303030 @color/background_material_dark